### PR TITLE
Add version attribute for the OpenAPI descriptor

### DIFF
--- a/dss-demo-webapp/src/main/java/eu/europa/esig/dss/web/config/CXFConfig.java
+++ b/dss-demo-webapp/src/main/java/eu/europa/esig/dss/web/config/CXFConfig.java
@@ -340,6 +340,7 @@ public class CXFConfig {
         openApiFeature.setScan(true);
 		openApiFeature.setUseContextBasedConfig(true);
         openApiFeature.setTitle("DSS WebServices");
+		openApiFeature.setVersion("1.0.0");
         return openApiFeature;
     }
 


### PR DESCRIPTION
Fixes https://ec.europa.eu/cefdigital/tracker/projects/DSS/issues/DSS-2440 .

In OpenAPIv3, the version attribute for the descriptor is required.